### PR TITLE
Add Click-based CLI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # pytavoas
-Python script for Tavern test file from OpenAPI definitions
+
+A CLI tool to generate [Tavern](https://taverntesting.github.io/) test
+templates from OpenAPI definitions and optionally output a list of
+endpoints to an Excel file.
+
+## Installation
+
+Install from source in an environment with Python 3.11 or higher:
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+The command line tool provides two subcommands using
+[click](https://pypi.org/project/click/):
+
+```bash
+pytavoas generate path/to/openapi.yaml --output-dir tests
+pytavoas endpoints path/to/openapi.yaml --excel endpoints.xlsx
+```
+
+`generate` creates Tavern YAML templates, while `endpoints` lists the
+available endpoints and can optionally write them to an Excel file.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pytavoas"
+version = "0.1.0"
+authors = [{name = "pytavoas", email = "example@example.com"}]
+description = "Generate Tavern tests and endpoint docs from OpenAPI definitions"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = ["click"]
+
+[project.scripts]
+pytavoas = "pytavoas.cli:main"
+
+

--- a/src/pytavoas/__init__.py
+++ b/src/pytavoas/__init__.py
@@ -1,0 +1,3 @@
+"""pytavoas package."""
+
+__all__ = ["cli"]

--- a/src/pytavoas/cli.py
+++ b/src/pytavoas/cli.py
@@ -1,0 +1,42 @@
+"""Command line interface for pytavoas."""
+
+import click
+
+from . import generate, endpoints
+
+@click.group()
+def cli():
+    """pytavoas command line."""
+
+@cli.command()
+@click.argument("openapi_file", type=click.Path(exists=True))
+@click.option(
+    "--output-dir",
+    default="tests",
+    help="Directory to write Tavern test templates.",
+    show_default=True,
+)
+def generate_cmd(openapi_file: str, output_dir: str) -> None:
+    """Generate Tavern test templates from OPENAPI_FILE."""
+    generate.generate(openapi_file, output_dir)
+
+
+@cli.command()
+@click.argument("openapi_file", type=click.Path(exists=True))
+@click.option(
+    "--excel",
+    type=click.Path(),
+    help="Write endpoints summary to an Excel file if provided.",
+)
+def endpoints_cmd(openapi_file: str, excel: str | None) -> None:
+    """List endpoints defined in OPENAPI_FILE."""
+    endpoints.list_endpoints(openapi_file, excel)
+
+
+def main() -> None:
+    """Entry point for console_scripts."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pytavoas/endpoints.py
+++ b/src/pytavoas/endpoints.py
@@ -1,0 +1,35 @@
+"""Utilities for listing OpenAPI endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+
+def _parse_openapi(file_path: Path) -> Iterable[str]:
+    """Parse OpenAPI file and yield endpoint paths.
+
+    This is a simplified placeholder implementation.
+    """
+    # TODO: Implement real parser for OpenAPI specification.
+    # Here we just return a fixed list for demonstration.
+    return ["/users", "/items"]
+
+
+def list_endpoints(openapi_file: str, excel: str | None = None) -> None:
+    """List endpoints and optionally write them to an Excel file."""
+    file_path = Path(openapi_file)
+    endpoints = list(_parse_openapi(file_path))
+    for ep in endpoints:
+        print(ep)
+
+    if excel:
+        try:
+            import pandas as pd  # type: ignore
+        except Exception as exc:  # pragma: no cover - error path
+            raise RuntimeError(
+                "pandas is required for writing Excel files"
+            ) from exc
+        df = pd.DataFrame({"endpoint": endpoints})
+        df.to_excel(excel, index=False)
+

--- a/src/pytavoas/generate.py
+++ b/src/pytavoas/generate.py
@@ -1,0 +1,19 @@
+"""Utilities for generating Tavern test templates from OpenAPI definitions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def generate(openapi_file: str, output_dir: str) -> None:
+    """Generate Tavern YAML templates from OPENAPI_FILE."""
+    input_path = Path(openapi_file)
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # TODO: Parse the OpenAPI file and generate Tavern templates.
+    # For now just create a placeholder file.
+    placeholder = out_dir / "placeholder.tavern.yaml"
+    placeholder.write_text(
+        f"# Tavern test templates generated from {input_path.name}\n"
+    )
+


### PR DESCRIPTION
## Summary
- set up basic Python package with `pyproject.toml`
- implement CLI using click with `generate` and `endpoints` subcommands
- stub out generation and endpoint listing helpers
- document usage in README

## Testing
- `pip install -e .`
- `pytavoas --help`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885847aefbc8320b4a10ced23afdf95