### PR TITLE
Fix CLI integration and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ The command line tool provides two subcommands using
 [click](https://pypi.org/project/click/):
 
 ```bash
-pytavoas generate path/to/openapi.yaml --output-dir tests
-pytavoas endpoints path/to/openapi.yaml --excel endpoints.xlsx
+# Generate Tavern test templates using a scenario and Jinja template
+pytavoas generate openapi.yaml scenario.yaml template_scenario.j2 \
+    output/test_scenario.tavern.yaml
+
+# List all endpoints to an Excel file
+pytavoas endpoints openapi.yaml output/openapi_operations.xlsx
 ```
 
-`generate` creates Tavern YAML templates, while `endpoints` lists the
-available endpoints and can optionally write them to an Excel file.
+`generate` reads an OpenAPI document, scenario YAML and Jinja2 template and
+writes a Tavern test file. `endpoints` lists the available operations and can
+output them to an Excel spreadsheet.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,12 @@ authors = [{name = "pytavoas", email = "example@example.com"}]
 description = "Generate Tavern tests and endpoint docs from OpenAPI definitions"
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["click"]
+dependencies = [
+    "click",
+    "Jinja2",
+    "openpyxl",
+    "PyYAML",
+]
 
 [project.scripts]
 pytavoas = "pytavoas.cli:main"

--- a/src/pytavoas/cli.py
+++ b/src/pytavoas/cli.py
@@ -14,22 +14,22 @@ def cli():
 @click.argument("openapi_file", type=click.Path(exists=True))
 @click.argument("scenario_file", type=click.Path(exists=True))
 @click.argument("template_file", type=click.Path(exists=True))
-@click.argument("output_file", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path())
 def generate_cmd(
     openapi_file: str, scenario_file: str, template_file: str, output_file: str
 ) -> None:
     """Generate Tavern test templates from OPENAPI_FILE."""
     generate.generate(
         openapi_file=openapi_file,
-        scenario_file="scenario.yaml",
-        template_file="template_scenario.j2",
-        output_file="output/test_scenario.tavern.yaml",
+        scenario_file=scenario_file,
+        template_file=template_file,
+        output_file=output_file,
     )
 
 
 @cli.command()
 @click.argument("openapi_file", type=click.Path(exists=True))
-@click.argument("output_file", type=click.Path(exists=True))
+@click.argument("output_file", type=click.Path())
 def endpoints_cmd(openapi_file: str, output_file: str) -> None:
     """List endpoints defined in OPENAPI_FILE."""
     endpoints.list_endpoints(input_file=openapi_file, output_file=output_file)


### PR DESCRIPTION
## Summary
- fix argument passing in CLI commands
- add required dependencies in `pyproject.toml`
- update README usage instructions

## Testing
- `pip install -e .`
- `pytavoas --help`
- `pytavoas generate --help`
- `pytavoas endpoints --help`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_68858917613483209d9822300e203285