### PR TITLE
Enable pip installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,10 @@ dependencies = [
 [project.scripts]
 pytavoas = "pytavoas.cli:main"
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 


### PR DESCRIPTION
## Summary
- add setuptools discovery section to pyproject

## Testing
- `pytest -q`
- `pip install . --no-build-isolation --force-reinstall --no-deps -v`

------
https://chatgpt.com/codex/tasks/task_e_6885a05801108320afc19f456e45d8a8